### PR TITLE
CellBroadcastReceiver: switch using SettingsLib styles

### DIFF
--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -22,15 +22,18 @@
     <!-- This must be a fullscreen theme for the alarm to be able to turn the screen on. -->
     <style name="AlertFullScreenTheme" parent="android:Theme.Material.Wallpaper.NoTitleBar" />
 
-    <style name="PreferenceTheme" parent="@style/PreferenceThemeOverlay.v14.Material">
+    <!--<style name="PreferenceTheme" parent="@style/PreferenceThemeOverlay.v14.Material">
         <item name="switchPreferenceStyle">@style/SettingsSwitchPreference</item>
         <item name="preferenceCategoryStyle">@style/SettingsPreferenceCategory</item>
         <item name="preferenceStyle">@style/SettingsPreference</item>
         <item name="dialogPreferenceStyle">@style/SettingsDialogPreference</item>
-    </style>
+    </style>-->
 
     <style name="CellBroadcastSettingsTheme" parent="@android:style/Theme.DeviceDefault.Settings">
         <item name="preferenceTheme">@style/PreferenceTheme</item>
+    </style>
+
+    <style name="PreferenceTheme" parent="@style/PreferenceThemeOverlay.SettingsBase">
     </style>
 
 </resources>


### PR DESCRIPTION
why use it and then dont inherit the global style?

Change-Id: Ic2d5b4cff3fd09d7f4da9ad437721609d3020c9d